### PR TITLE
Change documentation URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## Installing MongoDB 5 for Component Pack 8
 
-Please refer to the [documentation](https://opensource.hcltechsw.com/connections-doc/admin/install/installing_mongodb_5_for_component_pack_8.html) to build and install MongoDB 5 for Component Pack 8.
+Please refer to the [documentation](https://opensource.hcltechsw.com/connections-doc/v8-cr1/admin/install/installing_mongodb_5_for_component_pack_8.html) to build and install MongoDB 5 for Component Pack 8.
 
 ## Migrate MongoDB 3 data to MongoDB 5
 
-Please refer to the [documentation](https://opensource.hcltechsw.com/connections-doc/admin/install/migrating_data_mongodb_v3_v5.html) to migrate data from MongoDB 3 to 5.
+Please refer to the [documentation](https://opensource.hcltechsw.com/connections-doc/v8-cr1/admin/install/migrating_data_mongodb_v3_v5.html) to migrate data from MongoDB 3 to 5.
 


### PR DESCRIPTION
Links pointed to initial 8 documentation, with CR1 the folder structure changed and so the links opens a manual redirect which points to the first documentation page, but not the ones for MongoDB.